### PR TITLE
Pebworth testing

### DIFF
--- a/R/callPeaks_population.R
+++ b/R/callPeaks_population.R
@@ -29,6 +29,7 @@ callPeaks_by_population <- function(ArchRProj,
                       cellSubsets=NULL,
                       cellCol_label_name=NULL,
                       returnAllPeaks=FALSE,
+		      scaleFactor = NULL,
                       numCores=10
                      
                      ){
@@ -81,13 +82,15 @@ callPeaks_by_population <- function(ArchRProj,
     }
 
     
-    ### obtain median # of fragments
-    ### per cell to calibrate features
-    ### to pre-trained model 
-    medianFrags_current = median(ArchRProj@cellColData$nFrags)
+    if(is.null(scaleFactor)){
+    	### obtain median # of fragments
+    	### per cell to calibrate features
+    	### to pre-trained model 
+    	medianFrags_current = median(ArchRProj@cellColData$nFrags)
     
-    ### identify scaling factor 
-    scaleFactor= medianFrags_training/ medianFrags_current
+    	### identify scaling factor
+    	scaleFactor= medianFrags_training/ medianFrags_current
+    }
     
     cat(paste('\nScale factor is ', round(scaleFactor,2),'\n\n'))
 

--- a/R/callPeaks_sample.R
+++ b/R/callPeaks_sample.R
@@ -32,6 +32,7 @@ callPeaks_by_sample <- function(ArchRProj,
                       cellCol_label_name=NULL,
                       sampleCol_label_name="Sample",                                
                       returnAllPeaks=FALSE,
+		      scaleFactor = NULL,
                       numCores=10
                      
                      ){
@@ -86,13 +87,15 @@ callPeaks_by_sample <- function(ArchRProj,
 
     unique_samples <- unique(meta[,sampleCol_label_name])
     
-    ### obtain median # of fragments
-    ### per cell to calibrate features
-    ### to pre-trained model 
-    medianFrags_current = median(ArchRProj@cellColData$nFrags)
+    if(is.null(scaleFactor)){
+    	### obtain median # of fragments
+    	### per cell to calibrate features
+    	### to pre-trained model 
+    	medianFrags_current = median(ArchRProj@cellColData$nFrags)
     
-    ### identify scaling factor 
-    scaleFactor= medianFrags_training/ medianFrags_current
+    	### identify scaling factor
+    	scaleFactor= medianFrags_training/ medianFrags_current
+    }
     
     cat(paste('\nScale factor is ', round(scaleFactor,2),'\n\n'))
 


### PR DESCRIPTION
Here's code that:

- Speeds up the fragment extraction
- Enables sample specific peak calls for hashed experiments
- Enables proper subsampling for a given ArchR project by allowing the user to set a fixed scaleFactor.

This last feature was added because the scaleFactor is based on median fragments for the over all project - regardless of cell number. When running iterations where you subsample cells into a smaller ArchRProj, the scale factor can vary greatly, depending on the total number of cells subsampled within the ArchR project. This does not accurately predict peak calling, which needs the overall distribution across all cell types/samples for calibration. 

