### PR TITLE
Sorting SampleData before making SE object

### DIFF
--- a/R/getSampleTileMatrix.R
+++ b/R/getSampleTileMatrix.R
@@ -101,10 +101,10 @@ getSampleTileMatrix <- function(tileResults,
     )
   }, mc.cores = numCores)
     
-  #Order sampleData rows to match the same order as the columns. 
+  # Order sampleData rows to match the same order as the columns
   maxMat <- which.max(lapply(sampleTileIntensityMatList, ncol))
   colOrder <- colnames(sampleTileIntensityMatList[[maxMat]])
-  sampleData <-sampleData[match(colOrder, rownames(sampleData)),]
+  sampleData <- sampleData[match(colOrder, rownames(sampleData)),]
     
   tilePresence <- lapply(tilesByCellPop, function(x) (allTiles %in% x)) %>%
     do.call("cbind", .) %>%


### PR DESCRIPTION
Small fix for SampleData. 

When you make the SummarizedExperiment, it'll hit the error if the sample data (i.e. colData) doesn't match the order of the columns in the experiment. I added code to fix that, including a way to deal with reorder if there was sample dropout. 
