### PR TITLE
Differential name change

### DIFF
--- a/R/getDifferentialAccessibleTiles.R
+++ b/R/getDifferentialAccessibleTiles.R
@@ -151,7 +151,7 @@ getDifferentialAccessibleTiles <- function(SampleTileObj,
 
 
   colnames(full_results) <- c(
-    "Tile", "P_value", "Test-Statistic", "Log2FC_C",
+    "Tile", "P_value", "Test_Statistic", "Log2FC_C",
     "MeanDiff", "Avg_Intensity_Case", "Pct0_Case",
     "Avg_Intensity_Control", "Pct0_Control", "FDR",
     "CellPopulation", "Foreground", "Background"


### PR DESCRIPTION
The Differential accessibility function outputs a GRanges object with one of the columns named 'Test-Statistic', which is not a clean variable name and breaks down stream code (R thinks it's Test - Statistic). This branch just changes it to Test_Statistic instead. 

I already validated that it works. 