### PR TITLE
Hotfix: unintended cluster re-creation and NA cell type error when summarizing metadata

### DIFF
--- a/R/callOpenTiles.R
+++ b/R/callOpenTiles.R
@@ -596,19 +596,31 @@ setMethod(
   sampleData <- suppressWarnings(
     sampleDataFromCellColData(cellColData, sampleLabel = "Sample")
   )
-    
+  
   summarizedData <- SummarizedExperiment::SummarizedExperiment(
     append(
       list(
-        "CellCounts" = allCellCounts[
-            match(rownames(additionalMetaData[[1]]), rownames(allCellCounts)),],
-        "FragmentCounts" = allFragmentCounts[
-            match(rownames(additionalMetaData[[1]]), rownames(allFragmentCounts)),]
+        "CellCounts" = allCellCounts,
+        "FragmentCounts" = allFragmentCounts
       ),
       additionalMetaData
     ),
     colData = sampleData
   )
+  
+  # Match cell populations in allCellCounts/allFragmentCounts to those
+  # in additionalMetaData, in case of NA cell populations
+  if(length(additionalMetaData) >= 1){
+    allCellCounts <- allCellCounts[
+      match(rownames(additionalMetaData[[1]]), rownames(allCellCounts))
+      , , drop=FALSE
+    ]
+    
+    allFragmentCounts <- allFragmentCounts[
+      match(rownames(additionalMetaData[[1]]), rownames(allFragmentCounts))
+      , , drop=FALSE
+    ]
+  }
 
   # Add experimentList to MultiAssayExperiment
   names(experimentList) <- cellPopulations

--- a/tests/testthat/test_callOpenTiles.R
+++ b/tests/testthat/test_callOpenTiles.R
@@ -111,7 +111,7 @@ if (
       ATACFragments = tiny_fragments,
       cellColData = tiny_cellColData,
       blackList = MOCHA::exampleBlackList,
-      genome = genome,
+      genome = "hg19",
       TxDb = TxDb,
       OrgDb = OrgDb,
       outDir = tempdir(),


### PR DESCRIPTION
Fixes unintended cluster creation, and edge cases where cell populations in additionalMetaData and allCellCounts/allFragmentCounts are not aligned (NA cell populations). Covers edge cases where dimensions are dropped and additionalMetaData is null.