### PR TITLE
Option to return GRangesList or list of GRanges for getPopFrags() 

### DIFF
--- a/R/callOpenTiles.R
+++ b/R/callOpenTiles.R
@@ -542,6 +542,7 @@ setMethod(
         cellPopLabel = cellPopLabel,
         cellSubsets = cellPop,
         numCores = cl,
+        returnGRangesList = FALSE,
         verbose = verbose
       )
     } else {

--- a/R/getPopFrags.R
+++ b/R/getPopFrags.R
@@ -11,6 +11,7 @@
 #'   the given cellPopLabel metadata column of the ArchR Project.
 #' @param poolSamples Set TRUE to pool sample-specific fragments by cell population. By default this is FALSE and sample-specific fragments are returned.
 #' @param numCores Number of cores to use.
+#' @param returnGRangesList Set FALSE to return as a list of GRanges. Default, TRUE, returns a GRangesList
 #' @param verbose Set TRUE to display additional messages. Default is FALSE.
 #'
 #' @return A list of GRanges containing fragments. Each GRanges corresponds to a
@@ -24,6 +25,7 @@ getPopFrags <- function(ArchRProj,
                         cellSubsets = "ALL",
                         poolSamples = FALSE,
                         numCores = 1,
+                        returnGRangesList = TRUE,
                         verbose = FALSE) {
   nFrags <- NULL
   # Turn off ArchR logging messages
@@ -187,8 +189,12 @@ getPopFrags <- function(ArchRProj,
   }
 
   rm(tmp_fragList)
-
-  return(GenomicRanges::GRangesList(popFrags))
+    
+  if (returnGRangesList){
+    return(GenomicRanges::GRangesList(popFrags))
+  } else {
+    return(popFrags)
+  }
 }
 
 #' Extract fragments from an arrow file based on one variable

--- a/man/getPopFrags.Rd
+++ b/man/getPopFrags.Rd
@@ -10,6 +10,7 @@ getPopFrags(
   cellSubsets = "ALL",
   poolSamples = FALSE,
   numCores = 1,
+  returnGRangesList = TRUE,
   verbose = FALSE
 )
 }
@@ -27,6 +28,8 @@ the given cellPopLabel metadata column of the ArchR Project.}
 \item{poolSamples}{Set TRUE to pool sample-specific fragments by cell population. By default this is FALSE and sample-specific fragments are returned.}
 
 \item{numCores}{Number of cores to use.}
+
+\item{returnGRangesList}{Set FALSE to return as a list of GRanges. Default, TRUE, returns a GRangesList}
 
 \item{verbose}{Set TRUE to display additional messages. Default is FALSE.}
 }


### PR DESCRIPTION
* Add flag parameter to getPopFrags() to control output object type (list of GRanges vs GRangesList)
* Default callOpenTiles() to use a simple list of GRanges to prevent errors for larger populations